### PR TITLE
ROS_HOSTNAME set to localhost for mavros running on a drone via kubernetes deployment

### DIFF
--- a/deployment/k8.mavros.arm64.yaml
+++ b/deployment/k8.mavros.arm64.yaml
@@ -31,10 +31,10 @@ spec:
             value: "px4"
           - name: MAVROS_TGT_SYSTEM
             value: "1"
-          # - name: ROS_HOSTNAME
-          #   value: "localhost"
-          # - name: ROS_MASTER_URI
-          #   value: "http://localhost:11311"
+          - name: ROS_HOSTNAME
+            value: "localhost"
+          - name: ROS_MASTER_URI
+            value: "http://localhost:11311"
           ports:
           - containerPort: 14553
             protocol: "UDP"


### PR DESCRIPTION
This minor PR sets ROS_HOSTNAME and ROS_MASTER_URI in the kubernetes mavros arm64 deploy. 
When running `hostNetwork:true` the ROS_HOSTNAME defaults to the hostname of the machine (e.g. clover-4419) rather than the container or localhost. When mavros on ROS1 attempts to connect to master, it complains it cannot contact its own server at https://clover-4419:39347. 

This is solved by explicitly setting ROS_HOSTNAME to localhost for ROS1. This is only necessary for running the container on a drone with hosNetwork enabled. 