### PR TITLE
Ros1 parameter bridge topics missing VEHICLE_NAMESPACE

### DIFF
--- a/system/mavros/mavros_setup.sh
+++ b/system/mavros/mavros_setup.sh
@@ -129,7 +129,7 @@ if [ ! -f "$BRIDGE_MOD_CONFIG_PATH" ]; then
     # This captures both frame_id: and child_frame_id
     # This then saves the output into $PX4_MOD_CONFIG_PATH
     sed -E "s/(topic: )(.+)/\1\/$VEHICLE_NAMESPACE\/\2/g" $BRIDGE_CONFIG_PATH > $BRIDGE_MOD_CONFIG_PATH
-    sed -E "s/(service: )(.+)/\1\/$VEHICLE_NAMESPACE\/\2/g" $BRIDGE_CONFIG_PATH > $BRIDGE_MOD_CONFIG_PATH
+    sed -E -i "s/(service: )(.+)/\1\/$VEHICLE_NAMESPACE\/\2/g" $BRIDGE_MOD_CONFIG_PATH
 else
     echo "Modified Bridge Config for $VEHICLE_NAMESPACE already exists at $BRIDGE_MOD_CONFIG_PATH. Using for launch"
 fi


### PR DESCRIPTION
This PR addresses the bug in which `bridge_config_mod.yaml` is written two twice. The first time adds VEHICLE_NAMESPACE to topics, the second appends it to the front of services. However the second time was overwriting the first as they were both reading from the original source. 

Change now ensure that the second write happens in place on the already modified configuration. 