### PR TITLE
Fix global_position/local error

### DIFF
--- a/system/mavros/config/bridge_config.yaml
+++ b/system/mavros/config/bridge_config.yaml
@@ -20,7 +20,7 @@ topics:
     topic: mavlink/from
     type: mavros_msgs/msg/Mavlink
   # 6.6 Global position
-  #- queue_size: 1
+  #- queue_size: 1 # TODO set up custom message to use nav_msgs/Odom
   #  topic: mavros/global_position/local
   #  type: geometry_msgs/msg/PoseWithCovarianceStamped
   - queue_size: 1
@@ -68,7 +68,7 @@ topics:
   - queue_size: 1
     topic: mavros/setpoint_position/global
     type: geographic_msgs/msg/GeoPoseStamped
-  - queue_size: 1 # TODO set up custom message to use nav_msgs/Odom
+  - queue_size: 1
     topic: mavros/setpoint_position/local
     type: geometry_msgs/msg/PoseStamped
   - queue_size: 1

--- a/system/mavros/config/bridge_config.yaml
+++ b/system/mavros/config/bridge_config.yaml
@@ -68,9 +68,9 @@ topics:
   - queue_size: 1
     topic: mavros/setpoint_position/global
     type: geographic_msgs/msg/GeoPoseStamped
-   - queue_size: 1 TODO set up custom message to use nav_msgs/Odom
-     topic: mavros/setpoint_position/local
-     type: geometry_msgs/msg/PoseStamped
+  - queue_size: 1 # TODO set up custom message to use nav_msgs/Odom
+    topic: mavros/setpoint_position/local
+    type: geometry_msgs/msg/PoseStamped
   - queue_size: 1
     topic: mavros/setpoint_position/global_to_local
     type: geographic_msgs/msg/GeoPoseStamped

--- a/system/mavros/config/bridge_config.yaml
+++ b/system/mavros/config/bridge_config.yaml
@@ -20,9 +20,9 @@ topics:
     topic: mavlink/from
     type: mavros_msgs/msg/Mavlink
   # 6.6 Global position
-  - queue_size: 1
-    topic: mavros/global_position/local
-    type: geometry_msgs/msg/PoseWithCovarianceStamped
+  #- queue_size: 1
+  #  topic: mavros/global_position/local
+  #  type: geometry_msgs/msg/PoseWithCovarianceStamped
   - queue_size: 1
     topic: mavros/global_position/global
     type: sensor_msgs/msg/NavSatFix
@@ -68,9 +68,9 @@ topics:
   - queue_size: 1
     topic: mavros/setpoint_position/global
     type: geographic_msgs/msg/GeoPoseStamped
-#   - queue_size: 1 TODO set up custom message to use nav_msgs/Odom
-#     topic: mavros/setpoint_position/local
-#     type: geometry_msgs/msg/PoseStamped
+   - queue_size: 1 TODO set up custom message to use nav_msgs/Odom
+     topic: mavros/setpoint_position/local
+     type: geometry_msgs/msg/PoseStamped
   - queue_size: 1
     topic: mavros/setpoint_position/global_to_local
     type: geographic_msgs/msg/GeoPoseStamped


### PR DESCRIPTION
This PR fixes the ros parameter bridge error in  which global_position/local types are inconsistent between ros1 and ros2. This PR fixes the previous fix in which the wrong section (setpoint_position/local) was commented out and thus broke all of the autonomous control methods we have. 