### PR TITLE
Update PX4 with Jinja Spawning

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This systems provides a number of key features.
 
 ## Documentation
 
-Please refer to the documentation at [https://starlinguas.github.io/ProjectStarling/](https://starlinguas.github.io/ProjectStarling/) for detailed instructions and explanations of how to use this system.
+Please refer to the documentation at [https://docs.starlinguas.dev/](https://docs.starlinguas.dev/) for detailed instructions and explanations of how to use this system.
 
 The documentation is built using [MKDocs](https://www.mkdocs.org/) and can be served locally.
 

--- a/docker-compose-2-drones.yml
+++ b/docker-compose-2-drones.yml
@@ -20,6 +20,7 @@ services:
       - "PX4_SIM_HOST=localhost"
       - "PX4_INSTANCE=0"
       - "IGNORE_FAILURE=true"
+      - "ENABLE_VIRTUAL_FRAMEBUFFER=false"
     depends_on:
       - simhost
     pid: "host" # Share Process ID Namespace
@@ -70,6 +71,7 @@ services:
       - "PX4_INSTANCE=1"
       - "IGNORE_FAILURE=true"
       - "PX4_SIM_INIT_LOC_X=2"
+      - "ENABLE_VIRTUAL_FRAMEBUFFER=false"
     depends_on:
       - simhost
     pid: "host" # Share Process ID Namespace

--- a/simulator/base/core/Dockerfile
+++ b/simulator/base/core/Dockerfile
@@ -59,6 +59,7 @@ RUN apt-get update \
       libjansson-dev \
       libtinyxml-dev \
       xvfb \
+      python3-jinja2 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install nvm

--- a/simulator/base/px4/px4builder.Dockerfile
+++ b/simulator/base/px4/px4builder.Dockerfile
@@ -6,7 +6,7 @@ FROM px4io/px4-dev-simulation-focal as px4builder
 
 # Fetch the PX4 code
 RUN git clone --recurse-submodules -j4 --depth 1 --shallow-submodules -j4 \
-    -b v1.11.3 https://github.com/PX4/PX4-Autopilot /src/PX4-Autopilot
+    -b v1.12.3 https://github.com/PX4/PX4-Autopilot /src/PX4-Autopilot
 
 # Switch to the workdir
 WORKDIR /src/PX4-Autopilot

--- a/simulator/base/px4/sitl.Dockerfile
+++ b/simulator/base/px4/sitl.Dockerfile
@@ -6,8 +6,6 @@
 INCLUDE+ ./px4builder.Dockerfile
 
 # Add support for remote host in SITL & build it
-# RUN git fetch --recurse-submodules=no origin fe7908feb0de5ee8a4465619098f09b987ab011d \
-#     && git cherry-pick --no-commit fe7908feb0de5ee8a4465619098f09b987ab011d
 RUN make px4_sitl
 
 FROM ros:foxy-ros-base-focal

--- a/simulator/base/px4/sitl.Dockerfile
+++ b/simulator/base/px4/sitl.Dockerfile
@@ -6,8 +6,8 @@
 INCLUDE+ ./px4builder.Dockerfile
 
 # Add support for remote host in SITL & build it
-RUN git fetch --recurse-submodules=no origin fe7908feb0de5ee8a4465619098f09b987ab011d \
-    && git cherry-pick --no-commit fe7908feb0de5ee8a4465619098f09b987ab011d
+# RUN git fetch --recurse-submodules=no origin fe7908feb0de5ee8a4465619098f09b987ab011d \
+#     && git cherry-pick --no-commit fe7908feb0de5ee8a4465619098f09b987ab011d
 RUN make px4_sitl
 
 FROM ros:foxy-ros-base-focal

--- a/simulator/base/px4/sitl.Dockerfile
+++ b/simulator/base/px4/sitl.Dockerfile
@@ -27,17 +27,17 @@ ENV PX4_SIM_FORCE_USE_SET_POSITION false
 ENV SIM_WD /sim_wd
 
 # Modify startup script to use environment for server IP
-RUN sed -i 's/simulator start -c $simulator_tcp_port/simulator start -t $PX4_SIM_IP $simulator_tcp_port/' /src/PX4-Autopilot/ROMFS/px4fmu_common/init.d-posix/rcS
+RUN sed -i 's/simulator start -c $simulator_tcp_port/simulator start -t $PX4_SIM_IP $simulator_tcp_port/' /src/PX4-Autopilot/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
 
 # Modify startup script to add partner IP for offboard script
-RUN sed -i 's/\(mavlink start -x -u $udp_offboard_port_local -r 4000000 -m onboard -o $udp_offboard_port_remote\)/\1 -t $PX4_OFFBOARD_IP/' /src/PX4-Autopilot/ROMFS/px4fmu_common/init.d-posix/rcS
+RUN sed -i 's/\(mavlink start -x -u $udp_offboard_port_local -r 4000000 -m onboard -o $udp_offboard_port_remote\)/\1 -t $PX4_OFFBOARD_IP -p/' /src/PX4-Autopilot/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink
 
 # Modify startup script to enable mavlink broadcasting
-RUN sed -i '/param set IMU_INTEG_RATE 250/a param set MAV_BROADCAST 1' /src/PX4-Autopilot/ROMFS/px4fmu_common/init.d-posix/rcS
+RUN sed -i '/param set IMU_INTEG_RATE 250/a param set MAV_${px4_instance}_BROADCAST 1' /src/PX4-Autopilot/ROMFS/px4fmu_common/init.d-posix/rcS
 
 # Modify startup script to change range of udp offboard remote connection ports (and remove line for if px4_instance > 9)
-RUN sed -i 's/udp_offboard_port_remote=$((14540+px4_instance))/udp_offboard_port_remote=$((PX4_OFFBOARD_PORT_BASE+px4_instance))/'  /src/PX4-Autopilot/ROMFS/px4fmu_common/init.d-posix/rcS
-RUN sed -i '/[ $px4_instance -gt 9 ] && udp_offboard_port_remote=14549 # use the same ports for more than 10 instances to avoid port overlaps/d' /src/PX4-Autopilot/ROMFS/px4fmu_common/init.d-posix/rcS
+RUN sed -i 's/udp_offboard_port_remote=$((14540+px4_instance))/udp_offboard_port_remote=$((PX4_OFFBOARD_PORT_BASE+px4_instance))/'  /src/PX4-Autopilot/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink
+RUN sed -i '/[ $px4_instance -gt 9 ] && udp_offboard_port_remote=14549 # use the same ports for more than 10 instances to avoid port overlaps/d' /src/PX4-Autopilot/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink
 
 # Add entrypoint to handle PX4_SIM_HOST instead of IP
 COPY entrypoint.sh /entrypoint.sh

--- a/simulator/vehicles/iris/Dockerfile
+++ b/simulator/vehicles/iris/Dockerfile
@@ -5,7 +5,7 @@ FROM ${REGISTRY}uobflightlabstarling/starling-sim-base-px4:${VERSION}
 # Copy in the vehicle launch file
 COPY iris.launch.xml /ros_ws/launch/
 COPY spawn_iris.sh /ros_ws/
-COPY xacro_launch.sh /ros.env.d/xacro/setup.bash
+COPY vehicle_setup.sh /ros.env.d/10_vehicle/setup.bash
 
 ENV PX4_SITL_PORT 4560
 ENV PX4_INSTANCE 0

--- a/simulator/vehicles/iris/vehicle_setup.sh
+++ b/simulator/vehicles/iris/vehicle_setup.sh
@@ -3,17 +3,15 @@ echo "---- xacro_launch.sh START ------------"
 src_path="/src/PX4-Autopilot"
 
 echo "Generating ${PX4_SIM_MODEL} instance ${PX4_INSTANCE} sysid ${PX4_SYSID}"
-python3 ${src_path}/Tools/sitl_gazebo/scripts/jinja_gen.py ${src_path}/Tools/sitl_gazebo/models/${PX4_SIM_MODEL}/${PX4_SIM_MODEL}.sdf.jinja ${src_path}/Tools/sitl_gazebo \
-    --mavlink_tcp_port $((4560+${PX4_SYSID})) --mavlink_udp_port $((14560+${PX4_SYSID})) --mavlink_id $((1+${PX4_SYSID})) \
-    --gst_udp_port $((5600+${PX4_SYSID})) --video_uri $((5600+${PX4_SYSID})) --mavlink_cam_udp_port $((14530+${PX4_SYSID})) \
+python3 ${src_path}/Tools/sitl_gazebo/scripts/jinja_gen.py \
+    ${src_path}/Tools/sitl_gazebo/models/${PX4_SIM_MODEL}/${PX4_SIM_MODEL}.sdf.jinja ${src_path}/Tools/sitl_gazebo \
+    --mavlink_tcp_port ${PX4_SITL_PORT} \
+    --mavlink_udp_port $((${PX4_OFFBOARD_PORT_BASE}+${PX4_INSTANCE})) \
+    --mavlink_id ${PX4_SYSID} \
+    # --gst_udp_port $((5600+${PX4_INSTANCE}))  \
+    # --video_uri $((5600+${PX4_INSTANCE}))  \
+    # --mavlink_cam_udp_port $((14530+${PX4_INSTANCE})) \
     --output-file /tmp/${PX4_SIM_MODEL}_${PX4_SYSID}.sdf
-
-# python3 ${src_path}/Tools/sitl_gazebo/scripts/xacro.py ${src_path}/Tools/sitl_gazebo/models/rotors_description/urdf/${PX4_SIM_MODEL}_base.xacro \
-#     rotors_description_dir:=${src_path}/Tools/sitl_gazebo/models/rotors_description \
-#     mavlink_tcp_port:=${PX4_SITL_PORT}  \
-#     -o /tmp/${PX4_SIM_MODEL}_${PX4_SYSID}.urdf
-
-# gz sdf -p  /tmp/${PX4_SIM_MODEL}_${PX4_SYSID}.urdf > /tmp/${PX4_SIM_MODEL}_${PX4_SYSID}.sdf
 
 echo "Model TCP Port set to: ${PX4_SITL_PORT}"
 echo "Specific SDF saved to /tmp/${PX4_SIM_MODEL}_${PX4_SYSID}.sdf"

--- a/simulator/vehicles/iris/vehicle_setup.sh
+++ b/simulator/vehicles/iris/vehicle_setup.sh
@@ -8,9 +8,6 @@ python3 ${src_path}/Tools/sitl_gazebo/scripts/jinja_gen.py \
     --mavlink_tcp_port ${PX4_SITL_PORT} \
     --mavlink_udp_port $((${PX4_OFFBOARD_PORT_BASE}+${PX4_INSTANCE})) \
     --mavlink_id ${PX4_SYSID} \
-    # --gst_udp_port $((5600+${PX4_INSTANCE}))  \
-    # --video_uri $((5600+${PX4_INSTANCE}))  \
-    # --mavlink_cam_udp_port $((14530+${PX4_INSTANCE})) \
     --output-file /tmp/${PX4_SIM_MODEL}_${PX4_SYSID}.sdf
 
 echo "Model TCP Port set to: ${PX4_SITL_PORT}"

--- a/simulator/vehicles/iris/vehicle_setup.sh
+++ b/simulator/vehicles/iris/vehicle_setup.sh
@@ -3,12 +3,17 @@ echo "---- xacro_launch.sh START ------------"
 src_path="/src/PX4-Autopilot"
 
 echo "Generating ${PX4_SIM_MODEL} instance ${PX4_INSTANCE} sysid ${PX4_SYSID}"
-python3 ${src_path}/Tools/sitl_gazebo/scripts/xacro.py ${src_path}/Tools/sitl_gazebo/models/rotors_description/urdf/${PX4_SIM_MODEL}_base.xacro \
-    rotors_description_dir:=${src_path}/Tools/sitl_gazebo/models/rotors_description \
-    mavlink_tcp_port:=${PX4_SITL_PORT}  \
-    -o /tmp/${PX4_SIM_MODEL}_${PX4_SYSID}.urdf
+python3 ${src_path}/Tools/sitl_gazebo/scripts/jinja_gen.py ${src_path}/Tools/sitl_gazebo/models/${PX4_SIM_MODEL}/${PX4_SIM_MODEL}.sdf.jinja ${src_path}/Tools/sitl_gazebo \
+    --mavlink_tcp_port $((4560+${PX4_SYSID})) --mavlink_udp_port $((14560+${PX4_SYSID})) --mavlink_id $((1+${PX4_SYSID})) \
+    --gst_udp_port $((5600+${PX4_SYSID})) --video_uri $((5600+${PX4_SYSID})) --mavlink_cam_udp_port $((14530+${PX4_SYSID})) \
+    --output-file /tmp/${PX4_SIM_MODEL}_${PX4_SYSID}.sdf
 
-gz sdf -p  /tmp/${PX4_SIM_MODEL}_${PX4_SYSID}.urdf > /tmp/${PX4_SIM_MODEL}_${PX4_SYSID}.sdf
+# python3 ${src_path}/Tools/sitl_gazebo/scripts/xacro.py ${src_path}/Tools/sitl_gazebo/models/rotors_description/urdf/${PX4_SIM_MODEL}_base.xacro \
+#     rotors_description_dir:=${src_path}/Tools/sitl_gazebo/models/rotors_description \
+#     mavlink_tcp_port:=${PX4_SITL_PORT}  \
+#     -o /tmp/${PX4_SIM_MODEL}_${PX4_SYSID}.urdf
+
+# gz sdf -p  /tmp/${PX4_SIM_MODEL}_${PX4_SYSID}.urdf > /tmp/${PX4_SIM_MODEL}_${PX4_SYSID}.sdf
 
 echo "Model TCP Port set to: ${PX4_SITL_PORT}"
 echo "Specific SDF saved to /tmp/${PX4_SIM_MODEL}_${PX4_SYSID}.sdf"


### PR DESCRIPTION
This PR updates the PX4 to latest stable release of v0.12.3. Closes #125 

So far primary changes have included deprecating the use of xacro and replacing with jinja2. This required the `xacro_launch.sh` script to be updated to use jinja2. It has also been renamed to a `vehicle_setup.sh`.  

Needs further testing to determine if other breaking changes exist. 