### PR TITLE
Extended topics sent through to ROS2 via parameter bridge 

### DIFF
--- a/system/mavros/config/bridge_config.yaml
+++ b/system/mavros/config/bridge_config.yaml
@@ -14,8 +14,14 @@ topics:
     topic: mavros/battery
     type: sensor_msgs/msg/BatteryState
   - queue_size: 1
+    topic: mavros/altitude
+    type: sensor_msgs/msg/Altitude
+  - queue_size: 1
     topic: mavros/extended_state
     type: mavros_msgs/msg/ExtendedState
+  - queue_size: 1
+    topic: mavros/imu/data
+    type: sensor_msgs/msg/Imu
   - queue_size: 1
     topic: mavlink/to
     type: mavros_msgs/msg/Mavlink
@@ -35,8 +41,23 @@ topics:
     topic: mavros/local_position/pose
     type: geometry_msgs/msg/PoseStamped
   - queue_size: 5
-    topic: mavros/local_position/velocity
+    topic: mavros/local_position/pose_cov
+    type: geometry_msgs/msg/PoseWithCovarianceStamped
+  - queue_size: 5
+    topic: mavros/local_position/velocity_local
     type: geometry_msgs/msg/TwistStamped
+  - queue_size: 5
+    topic: mavros/local_position/velocity_body
+    type: geometry_msgs/msg/TwistStamped
+  - queue_size: 5
+    topic: mavros/local_position/velocity_body_cov
+    type: geometry_msgs/msg/TwistWithCovarianceStamped
+  - queue_size: 5
+    topic: mavros/local_position/accel
+    type: geometry_msgs/msg/AccelWithCovarianceStamped
+  - queue_size: 5
+    topic: mavros/local_position/odom
+    type: nav_msgs/msg/Odometry
 
   # 6.9 Manual Control
   - queue_size: 1

--- a/system/mavros/config/bridge_config.yaml
+++ b/system/mavros/config/bridge_config.yaml
@@ -14,6 +14,9 @@ topics:
     topic: mavros/battery
     type: sensor_msgs/msg/BatteryState
   - queue_size: 1
+    topic: mavros/extended_state
+    type: mavros_msgs/msg/ExtendedState
+  - queue_size: 1
     topic: mavlink/to
     type: mavros_msgs/msg/Mavlink
   - queue_size: 1
@@ -32,7 +35,7 @@ topics:
     topic: mavros/local_position/pose
     type: geometry_msgs/msg/PoseStamped
   - queue_size: 5
-    topic: mavros/global_position/velocity
+    topic: mavros/local_position/velocity
     type: geometry_msgs/msg/TwistStamped
 
   # 6.9 Manual Control


### PR DESCRIPTION
This PR adds a number of mavros topics which are being proxied over from ROS1 to ROS2.

This will include a number of local_position variables among others. 