### PR TITLE
Dynamically set display number

### DIFF
--- a/simulator/base/core/setup_display.sh
+++ b/simulator/base/core/setup_display.sh
@@ -3,12 +3,12 @@ echo "--------------- Start setup_display.sh ----------------------"
 
 if [ "$ENABLE_VIRTUAL_FRAMEBUFFER" = true ]; then
     echo "Creating virtual display using virtual framebuffer"
-    export DISPLAY=:1
-    rm -f /tmp/.X1-lock
-    Xvfb $DISPLAY -screen 0 1600x900x24 &
+    Xvfb -displayfd 3 -screen 0 1600x900x24 3>/tmp/displaynum &
+    while [ "$(cat /tmp/displaynum)" == "" ]; do sleep 0.1; done
+    export DISPLAY=:$(cat /tmp/displaynum)
 
     echo "Waiting for display to become available"
-    while [ ! -e /tmp/.X11-unix/X1 ]; do echo "Wait for X server.."; sleep 0.1; done
+    while [ ! -e /tmp/.X11-unix/X${DISPLAY#:} ]; do echo "Wait for X server.."; sleep 0.1; done
 else
     echo "Virtual Framebuffer Disabled"
 fi


### PR DESCRIPTION
Previous version of the script assumed display number 1 would be available. This was not the case on some machines and led to #138.

This PR makes `Xvfb` search for an available display number rather than assigning one statically.

Fixes #138 
Fixes StarlingUAS/FenswoodScenario#15
