### PR TITLE
Add -f to sed in sitl.Dockerfile mavlink config modification 

### DIFF
--- a/simulator/base/px4/sitl.Dockerfile
+++ b/simulator/base/px4/sitl.Dockerfile
@@ -28,7 +28,9 @@ ENV SIM_WD /sim_wd
 RUN sed -i 's/simulator start -c $simulator_tcp_port/simulator start -t $PX4_SIM_IP $simulator_tcp_port/' /src/PX4-Autopilot/ROMFS/px4fmu_common/init.d-posix/px4-rc.simulator
 
 # Modify startup script to add partner IP for offboard script
-RUN sed -i 's/\(mavlink start -x -u $udp_offboard_port_local -r 4000000 -m onboard -o $udp_offboard_port_remote\)/\1 -t $PX4_OFFBOARD_IP -p/' /src/PX4-Autopilot/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink
+RUN sed -i 's/\(mavlink start -x -u $udp_offboard_port_local -r 4000000 -f -m onboard -o $udp_offboard_port_remote\)/\1 -t $PX4_OFFBOARD_IP -p/' /src/PX4-Autopilot/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink
+RUN sed -i '/udp_onboard_payload_port_local/d' /src/PX4-Autopilot/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink
+RUN sed -i '/udp_onboard_gimbal_port_local/d' /src/PX4-Autopilot/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink
 
 # Modify startup script to enable mavlink broadcasting
 RUN sed -i '/param set IMU_INTEG_RATE 250/a param set MAV_${px4_instance}_BROADCAST 1' /src/PX4-Autopilot/ROMFS/px4fmu_common/init.d-posix/rcS


### PR DESCRIPTION
Modified dockerfile sed to match mavlink start. Unknown how this was missed out in latest release. 
Also removed the starting of the payload and gimbal  as they are both unnecessary and cause extra printouts. 

Confusingly the following line still exists:
```
sitl_1             | INFO  [mavlink] MAVLink only on localhost (set param MAV_{i}_BROADCAST = 1 to enable network)
``` 
But it is unknown how to get rid of this error as, we do indeed set that parameter within the dockerfile, and it is verified that the parameter  is indeed changed inside the container. But it works so moving on for now. 
