### PR TITLE
Add Rangefinder to IRIS-AP

### DIFF
--- a/simulator/vehicles/iris-ap/models/iris_ap/model.sdf.xacro
+++ b/simulator/vehicles/iris-ap/models/iris_ap/model.sdf.xacro
@@ -43,7 +43,7 @@
         </inertia>
       </inertial>
       <!-- Visuals / Collisions omitted for this example -->
-      <sensor type="gpu_ray" name="head_hokuyo_sensor">
+      <sensor type="ray" name="head_hokuyo_sensor">
         <ray>
           <scan>
             <horizontal>

--- a/simulator/vehicles/iris-ap/models/iris_ap/model.sdf.xacro
+++ b/simulator/vehicles/iris-ap/models/iris_ap/model.sdf.xacro
@@ -29,15 +29,19 @@
     </joint>
 
     <link name="hokuyo_link">
-      <pose>-0.5 0 -1 0 -1.57075 0</pose>
-      <!-- <visual name="my_visual">
-          <pose>0 0 0 0 0</pose>
-          <geometry>
-            <box>
-              <size>1.0 0.1 0.1</size>
-            </box>
-          </geometry>
-      </visual> -->
+      <pose>0 0 0 0 1.57075 0</pose>
+      <inertial>
+        <mass>0.016</mass>
+        <inertia>
+          <ixx>0.0001</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.0001</iyy>
+          <iyz>0</iyz>
+          <izz>0.0001</izz>
+        <!-- low intertia necessary to avoid to disturb the drone -->
+        </inertia>
+      </inertial>
       <!-- Visuals / Collisions omitted for this example -->
       <sensor type="gpu_ray" name="head_hokuyo_sensor">
         <ray>
@@ -56,8 +60,8 @@
             </vertical>
           </scan>
           <range>
-            <min>0.10</min>
-            <max>10.0</max>
+            <min>0.01</min>
+            <max>20.0</max>
             <resolution>0.01</resolution>
           </range>
           <!-- Using gazebo's noise instead of plugin's -->

--- a/simulator/vehicles/iris-ap/models/iris_ap/model.sdf.xacro
+++ b/simulator/vehicles/iris-ap/models/iris_ap/model.sdf.xacro
@@ -29,6 +29,15 @@
     </joint>
 
     <link name="hokuyo_link">
+      <pose>-0.5 0 -1 0 -1.57075 0</pose>
+      <!-- <visual name="my_visual">
+          <pose>0 0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>1.0 0.1 0.1</size>
+            </box>
+          </geometry>
+      </visual> -->
       <!-- Visuals / Collisions omitted for this example -->
       <sensor type="gpu_ray" name="head_hokuyo_sensor">
         <ray>
@@ -74,10 +83,10 @@
       </sensor>
     </link>
 
-    <joint name="iris_hokuyo_mount" type="revolute">
+    <joint name="iris_hokuyo_mount" type="fixed">
       <parent>iris::base_link</parent>
       <child>hokuyo_link</child>
-      <axis>
+      <!-- <axis>
         <limit>
           <lower>0</lower>
           <upper>0</upper>
@@ -85,7 +94,7 @@
         <xyz>-1 0 1</xyz>
         <rpy>0 0.0 0</rpy>
         <use_parent_model_frame>true</use_parent_model_frame>
-      </axis>
+      </axis> -->
     </joint>
 
     <!-- plugins -->

--- a/simulator/vehicles/iris-ap/models/iris_ap/model.sdf.xacro
+++ b/simulator/vehicles/iris-ap/models/iris_ap/model.sdf.xacro
@@ -2,6 +2,7 @@
 <sdf version="1.6" xmlns:xacro='http://ros.org/wiki/xacro'>
   <!-- <xacro:arg name="fdm_addr" default="127.0.0.1"/> -->
   <!-- <xacro:arg name="listen_addr" default="127.0.0.1"/> -->
+  <xacro:property name="ros_namespace" value="$(arg ros_namespace)"/>
   <xacro:property name="fdm_addr" value="$(arg fdm_addr)"/>
   <xacro:property name="listen_addr" value="$(arg listen_addr)"/>
   <model name="iris_demo">
@@ -23,6 +24,66 @@
           <upper>0</upper>
         </limit>
         <xyz>0 0 1</xyz>
+        <use_parent_model_frame>true</use_parent_model_frame>
+      </axis>
+    </joint>
+
+    <link name="hokuyo_link">
+      <!-- Visuals / Collisions omitted for this example -->
+      <sensor type="gpu_ray" name="head_hokuyo_sensor">
+        <ray>
+          <scan>
+            <horizontal>
+              <samples>10</samples>
+              <resolution>1</resolution>
+              <min_angle>-0.087</min_angle>
+              <max_angle>0.087</max_angle>
+            </horizontal>
+            <vertical>
+              <samples>10</samples>
+              <resolution>1</resolution>
+              <min_angle>-0.087</min_angle>
+              <max_angle>0.087</max_angle>
+            </vertical>
+          </scan>
+          <range>
+            <min>0.10</min>
+            <max>10.0</max>
+            <resolution>0.01</resolution>
+          </range>
+          <!-- Using gazebo's noise instead of plugin's -->
+          <noise>
+            <type>gaussian</type>
+            <mean>0.0</mean>
+            <stddev>0.01</stddev>
+          </noise>
+        </ray>
+        <!-- Using gazebo's update rate instead of plugin's -->
+        <update_rate>30</update_rate>
+
+        <plugin name="laser" filename="libgazebo_ros_ray_sensor.so">
+          <!-- Change namespace and output topic so published topic is /rrbot/laser/scan -->
+          <ros>
+            <namespace>${ros_namespace}</namespace>
+          </ros>
+          <!-- Set output to sensor_msgs/LaserScan to get same output type as gazebo_ros_laser -->
+          <output_type>sensor_msgs/Range</output_type>
+          <!-- <frame_name> ommited, will default to hokuo_link -->
+          <radiation_type>infrared</radiation_type>
+        </plugin>
+      </sensor>
+    </link>
+
+    <joint name="iris_hokuyo_mount" type="revolute">
+      <parent>iris::base_link</parent>
+      <child>hokuyo_link</child>
+      <axis>
+        <limit>
+          <lower>0</lower>
+          <upper>0</upper>
+        </limit>
+        <xyz>-1 0 1</xyz>
+        <rpy>0 0.0 0</rpy>
         <use_parent_model_frame>true</use_parent_model_frame>
       </axis>
     </joint>

--- a/simulator/vehicles/iris-ap/models/iris_ap/setup.bash
+++ b/simulator/vehicles/iris-ap/models/iris_ap/setup.bash
@@ -5,6 +5,7 @@ XACRO_PATH=${SCRIPT_DIR}/model.sdf.xacro
 MODEL_PATH=/ardupilot_gazebo/models/iris_with_ardupilot/model.sdf
 
 xacro ${XACRO_PATH} \
+    ros_namespace:=${VEHICLE_NAMESPACE} \
     fdm_addr:=${AP_SITL_ADDRESS} \
     listen_addr:=0.0.0.0 \
     -o ${MODEL_PATH}


### PR DESCRIPTION
This PR adds a rangefinder to the IRIS-AP simulation

It is simply directly added to the vehicle xacro file

TODO
- [x] Check orientation of rangefinder