### PR TITLE
Add User Configurable Mavros Bridge Launch Delay

### DIFF
--- a/docs/docker-images/mavros.md
+++ b/docs/docker-images/mavros.md
@@ -43,6 +43,7 @@ Name                      | Default Value                  | Description
 `MAVROS_MOD_CONFIG_PATH`  | "/mavros_config_mod.yaml"      | Path for modified MAVROS config to be written to
 `BRIDGE_CONFIG_PATH`      | "/bridge_config.yaml"          | Path for initial bridge config file
 `BRIDGE_MOD_CONFIG_PATH`  | "/bridge_config_mod.yaml"      | Path for modified bridge config to be written to
+`BRIDGE_LAUNCH_DELAY`     | 2.0                            | Time delay in seconds between starting ROS1 mavros and the ROS1-2 bridge. Increasing this value reduces the chance of a race condition causing mavros failure due to the bridge being unable to read ros1 parameters. See [this issue](https://github.com/StarlingUAS/ProjectStarling/issues/124) for more details. Recommendation is to increase the value to 10 seconds if this occurs. 
 
 
 ### Configuring the Connection

--- a/system/mavros/mavros_bridge.launch.xml
+++ b/system/mavros/mavros_bridge.launch.xml
@@ -9,6 +9,7 @@
     <arg name="config_yaml" default="$(env MAVROS_MOD_CONFIG_PATH)"/>
     <arg name="pluginlists_yaml" default="$(env MAVROS_PLUGINLISTS_PATH)"/>
     <arg name="bridge_yaml" default="$(env BRIDGE_MOD_CONFIG_PATH)"/>
+    <arg name="bridge_launch_delay" default="$(env BRIDGE_LAUNCH_DELAY 2.0)"/>
 
     <!-- Launch the ROS1 stack -->
     <executable cmd="/ros_ws/scripts/run_ros1.sh roslaunch /ros_ws/launch/mavros.launch
@@ -32,7 +33,7 @@
           args="/$(var vehicle_namespace)/topics /$(var vehicle_namespace)/services_1to2 /$(var vehicle_namespace)/services_2to1"
           namespace="$(var vehicle_namespace)"
           respawn="true"
-          launch-prefix="bash -c 'sleep 2.0; $0 $@' ">
+          launch-prefix="bash -c 'sleep $(var bridge_launch_delay); $0 $@' ">
     </node>
 
 </launch>


### PR DESCRIPTION
This PR Addresses #124 

It is thought that #124  is caused by a race condition between ros1 starting and the ros2 bridge starting. Ros1 must start before ros2 bridge and the bridge reads ros1 parameters. If ros1 takes a long time to start, especially due to computer resource constraints or high load, the ros2 bridge will fail silently. 

This PR introduces a environment variable `BRIDGE_LAUNCH_DELAY` (defaults to 2 seconds) to allow the user to set the delay without needing to recompile mavros. Especially on kubernetes systems, setting this to a value such as 10.0 seconds will provide more reliability. 