### PR TITLE
Estop within Mavros Container

### DIFF
--- a/docs/docker-images/mavros.md
+++ b/docs/docker-images/mavros.md
@@ -21,6 +21,10 @@ The image has been setup to automatically configure itself in some scenarios:
  - Running on a vehicle
  - Running in Kubernetes
 
+There are also some additional general nodes running in the background. In particular:
+
+  - Emergency Stop listener on the `/emergency_stop` topic of type `std_msgs/msg/Empty`. It is hard-wired to forcefully disarm the vehicle (stop motors) for both PX4 and Ardupilot in simulation and reality.
+
 ## Configuration Options
 
 There are many configuration options available for this image to allow it to be used flexibly across different
@@ -43,7 +47,7 @@ Name                      | Default Value                  | Description
 `MAVROS_MOD_CONFIG_PATH`  | "/mavros_config_mod.yaml"      | Path for modified MAVROS config to be written to
 `BRIDGE_CONFIG_PATH`      | "/bridge_config.yaml"          | Path for initial bridge config file
 `BRIDGE_MOD_CONFIG_PATH`  | "/bridge_config_mod.yaml"      | Path for modified bridge config to be written to
-`BRIDGE_LAUNCH_DELAY`     | 2.0                            | Time delay in seconds between starting ROS1 mavros and the ROS1-2 bridge. Increasing this value reduces the chance of a race condition causing mavros failure due to the bridge being unable to read ros1 parameters. See [this issue](https://github.com/StarlingUAS/ProjectStarling/issues/124) for more details. Recommendation is to increase the value to 10 seconds if this occurs. 
+`BRIDGE_LAUNCH_DELAY`     | 2.0                            | Time delay in seconds between starting ROS1 mavros and the ROS1-2 bridge. Increasing this value reduces the chance of a race condition causing mavros failure due to the bridge being unable to read ros1 parameters. See [this issue](https://github.com/StarlingUAS/ProjectStarling/issues/124) for more details. Recommendation is to increase the value to 10 seconds if this occurs.
 
 
 ### Configuring the Connection
@@ -161,7 +165,7 @@ The first part of this is checking for the existance of the `/stc/starling/vehic
 is assumed that the container is running on a real vehicle. In this case, the file is sourced and values for the MAVLink
 system ID, vehicle name, FCU URL, and firmware type are obtained.
 
-The next phase is determining the appropriate target system ID. This is configured by the 
+The next phase is determining the appropriate target system ID. This is configured by the
 
 
 Once the setup script has run, the default behaviour is to launch the `mavros_bridge.launch.xml` file. This behaviour

--- a/simulator/base/core/Dockerfile
+++ b/simulator/base/core/Dockerfile
@@ -77,7 +77,6 @@ ENV GZWEB_WS /root/gzweb
 #RUN git clone -b gzweb_1.4.0-gazebo11 https://github.com/eurogroep/gzweb.git ${GZWEB_WS}
 # Additionally patched version
 RUN git clone --depth 1 -b gzweb_1.4.2 https://github.com/rob-clarke/gzweb.git ${GZWEB_WS}
-RUN sed -i "s$\"node-gyp\": \"\"$\"node-gyp\": \"8.4.1\"$" ${GZWEB_WS}/package.json
 
 # Build gzweb (default model generation)
 RUN source /ros.env \

--- a/simulator/base/core/Dockerfile
+++ b/simulator/base/core/Dockerfile
@@ -77,6 +77,7 @@ ENV GZWEB_WS /root/gzweb
 #RUN git clone -b gzweb_1.4.0-gazebo11 https://github.com/eurogroep/gzweb.git ${GZWEB_WS}
 # Additionally patched version
 RUN git clone --depth 1 -b gzweb_1.4.2 https://github.com/rob-clarke/gzweb.git ${GZWEB_WS}
+RUN sed -i "s$\"node-gyp\": \"\"$\"node-gyp\": \"8.4.1\"$" ${GZWEB_WS}/package.json
 
 # Build gzweb (default model generation)
 RUN source /ros.env \

--- a/system/mavros/Dockerfile
+++ b/system/mavros/Dockerfile
@@ -56,6 +56,14 @@ ENV MAVROS_PLUGINLISTS_PATH="/mavros_pluginlists_px4.yaml"
 ENV BRIDGE_MOD_CONFIG_PATH="/bridge_config_mod.yaml"
 ENV BRIDGE_CONFIG_PATH="/bridge_config.yaml"
 
+# Build extra custom nodes in Mavros
+COPY starling_mavros_extras /ros_ws/src/starling_mavros_extras
+RUN . /opt/ros/${ROS_DISTRO}/setup.sh \
+    && export CMAKE_PREFIX_PATH=$AMENT_PREFIX_PATH:$CMAKE_PREFIX_PATH \
+    && cd /ros_ws \
+    && colcon build --packages-select starling_mavros_extras \
+    && rm -r build
+
 # Add custom ROS DDS configuration (force UDP always)
 COPY fastrtps_profiles.xml /ros_ws/
 ENV FASTRTPS_DEFAULT_PROFILES_FILE /ros_ws/fastrtps_profiles.xml

--- a/system/mavros/mavros_bridge.launch.xml
+++ b/system/mavros/mavros_bridge.launch.xml
@@ -36,4 +36,7 @@
           launch-prefix="bash -c 'sleep $(var bridge_launch_delay); $0 $@' ">
     </node>
 
+    <!-- Launch Estop Node -->
+    <node name="estop" pkg="starling_mavros_extras" exec="estop" output="screen" respawn="true" namespace="$(var vehicle_namespace)"/>
+
 </launch>

--- a/system/mavros/ros_entrypoint.sh
+++ b/system/mavros/ros_entrypoint.sh
@@ -14,6 +14,9 @@ source "/opt/ros/$ROS2_DISTRO/setup.bash"
 # Source the from-source ros1_bridge workspace
 source "/bridge_ws/install/setup.bash"
 
+# Source any extra nodes inside mavros container
+source "/ros_ws/install/setup.bash"
+
 # Source the mavros_setup for any user defined edits to the environment
 source "/ros_ws/mavros_setup.sh"
 

--- a/system/mavros/starling_mavros_extras/CMakeLists.txt
+++ b/system/mavros/starling_mavros_extras/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 3.5)
+project(starling_mavros_extras)
+
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+# find dependencies
+find_package(ament_cmake REQUIRED)
+# uncomment the following section in order to fill in
+# further dependencies manually.
+# find_package(<dependency> REQUIRED)
+find_package(rclcpp  REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(mavros_msgs REQUIRED)
+
+set(HEADER_FILES include/estop.hpp)
+
+add_executable(estop src/estop.cpp ${HEADER_FILES})
+ament_target_dependencies(estop
+  rclcpp std_msgs mavros_msgs
+)
+target_include_directories(estop PRIVATE include)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # uncomment the line when a copyright and license is not present in all source files
+  #set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # uncomment the line when this package is not in a git repo
+  #set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+install(TARGETS
+  estop
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+ament_package()

--- a/system/mavros/starling_mavros_extras/include/estop.hpp
+++ b/system/mavros/starling_mavros_extras/include/estop.hpp
@@ -1,0 +1,41 @@
+#ifndef ESTOP_HPP
+#define ESTOP_HPP
+
+/*
+ * Trajectory follower
+ * Copyright (C) 2021 University of Bristol
+ *
+ * Author: Mickey Li <mickey.li@bristol.ac.uk> (University of Bristol)
+ *
+ * Distributed under MIT License (available at https://opensource.org/licenses/MIT).
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ */
+#include "rclcpp/rclcpp.hpp"
+
+#include <chrono>
+#include <memory>
+#include <boost/algorithm/string.hpp>
+#include <algorithm>
+#include <stdexcept>
+#include <thread>
+#include <atomic>
+#include <cmath>
+
+#include <std_msgs/msg/empty.hpp>
+#include "mavros_msgs/srv/command_long.hpp"
+
+
+class EstopHandler : public rclcpp::Node
+{
+    public:
+        EstopHandler();
+
+    private:
+        void emergency_stop();
+        rclcpp::Client<mavros_msgs::srv::CommandLong>::SharedPtr        mavros_command_srv;
+        rclcpp::Subscription<std_msgs::msg::Empty>::SharedPtr               estop_sub;
+};
+
+
+#endif

--- a/system/mavros/starling_mavros_extras/package.xml
+++ b/system/mavros/starling_mavros_extras/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>starling_mavros_extras</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="mickey.li14@imperial.ac.uk">root</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>std_msgs</depend>
+  <depend>mavros_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/system/mavros/starling_mavros_extras/src/estop.cpp
+++ b/system/mavros/starling_mavros_extras/src/estop.cpp
@@ -15,11 +15,14 @@ EstopHandler::EstopHandler() :
 {
     this->mavros_command_srv = this->create_client<mavros_msgs::srv::CommandLong>("mavros/cmd/command", rmw_qos_profile_services_default);
     this->estop_sub = this->create_subscription<std_msgs::msg::Empty>(
-        "/emergency_stop", 1, [this](const std_msgs::msg::Empty::SharedPtr s){(void)s;
-        this->emergency_stop();
-    });
+        "/emergency_stop", 1, 
+        [this](const std_msgs::msg::Empty::SharedPtr s){
+            (void)s;
+            this->emergency_stop();
+        }
+    );
 
-    RCLCPP_INFO(this->get_logger(), "Estop Initialised");
+    RCLCPP_INFO(this->get_logger(), "ESTOP Initialised");
 }
 
 void EstopHandler::emergency_stop() {

--- a/system/mavros/starling_mavros_extras/src/estop.cpp
+++ b/system/mavros/starling_mavros_extras/src/estop.cpp
@@ -1,0 +1,50 @@
+/*
+ * Trajectory follower
+ * Copyright (C) 2021 University of Bristol
+ *
+ * Author: Mickey Li <mickey.li@bristol.ac.uk> (University of Bristol)
+ *
+ * Distributed under MIT License (available at https://opensource.org/licenses/MIT).
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ */
+#include "estop.hpp"
+
+EstopHandler::EstopHandler() :
+	Node("estop_handler")
+{
+    this->mavros_command_srv = this->create_client<mavros_msgs::srv::CommandLong>("mavros/cmd/command", rmw_qos_profile_services_default);
+    this->estop_sub = this->create_subscription<std_msgs::msg::Empty>(
+        "/emergency_stop", 1, [this](const std_msgs::msg::Empty::SharedPtr s){(void)s;
+        this->emergency_stop();
+    });
+
+    RCLCPP_INFO(this->get_logger(), "Estop Initialised");
+}
+
+void EstopHandler::emergency_stop() {
+    RCLCPP_ERROR(this->get_logger(), "EMERGENCY STOP RECIEVED, SENDING KILL MESSAGE TO AUTOPILOT");
+    // Kill Drone Rotors
+    auto commandCall = std::make_shared<mavros_msgs::srv::CommandLong::Request>();
+    commandCall->broadcast = false;
+    commandCall->command = 400;
+    commandCall->param2 = 21196.0;
+    while (!this->mavros_command_srv->wait_for_service(std::chrono::duration<float>(0.1))) {
+        if (!rclcpp::ok()) {
+            RCLCPP_ERROR(this->get_logger(), "Interrupted while waiting for command service. Exiting.");
+            throw std::runtime_error("Interrupted while waiting for command service. Exiting.");
+            return;
+        }
+        RCLCPP_INFO(this->get_logger(), "service not available, waiting again...");
+    }
+    auto result_future = this->mavros_command_srv->async_send_request(commandCall);
+}
+
+int main(int argc, char **argv)
+{
+    rclcpp::init(argc, argv);
+    auto handler = std::make_shared<EstopHandler>();
+    rclcpp::spin(handler);
+    rclcpp::shutdown();
+    return 0;
+}


### PR DESCRIPTION
Closes #127 by adding the estop functionality into the mavros container directly. 

This CPP Node only listens to the `/emergency_stop` topic of type `std_msgs/msg/Empty` 

If something is received on this topic, it will immediately broadcast the custom command call which forces disarm (shuts motors). Checked that it is compatible to both PX4 and Ardupilot. 

All custom controllers should implement a softer `/mission_abort` functionality as the estop should be of last resort. 