### PR TITLE
Implemented ping monitor and tested locally

### DIFF
--- a/buildtools/docker-bake.hcl
+++ b/buildtools/docker-bake.hcl
@@ -45,7 +45,18 @@ group "stage3" {
  * System targets
  */
 group "system" {
-    targets = ["rosbridge-suite", "starling-controller-base", "starling-mavros", "starling-vicon", "mavp2p"]
+    targets = ["rosbridge-suite", "starling-controller-base", "starling-mavros", "starling-vicon", "mavp2p", "ping-monitor"]
+}
+
+target "ping-monitor" {
+    context = "system/ping_monitor"
+    tags = [
+        "${BAKE_REGISTRY}uobflightlabstarling/ping-monitor:${BAKE_VERSION}",
+        notequal("",BAKE_RELEASENAME) ? "${BAKE_REGISTRY}uobflightlabstarling/ping-monitor:${BAKE_RELEASENAME}": "",
+        ]
+    platforms = ["linux/amd64"]
+    cache-to = [ notequal("",BAKE_CACHETO_NAME) ? "${BAKE_CACHETO_REGISTRY}uobflightlabstarling/ping-monitor:${BAKE_CACHETO_NAME}" : "" ]
+    cache-from = [ notequal("",BAKE_CACHEFROM_NAME) ? "${BAKE_CACHEFROM_REGISTRY}uobflightlabstarling/ping-monitor:${BAKE_CACHEFROM_NAME}" : "" ]
 }
 
 target "rosbridge-suite" {

--- a/system/Makefile
+++ b/system/Makefile
@@ -23,4 +23,7 @@ mavp2p:
 vicon:
 	$(BAKE) starling-vicon
 
-.PHONY: mavros mavros_all_arch controller-base rosbridge-suite vicon mavp2p all
+ping-monitor:
+	$(BAKE) ping-monitor
+
+.PHONY: mavros mavros_all_arch controller-base rosbridge-suite vicon mavp2p all ping-monitor

--- a/system/mavros/mavros_bridge.launch.xml
+++ b/system/mavros/mavros_bridge.launch.xml
@@ -39,4 +39,9 @@
     <!-- Launch Estop Node -->
     <node name="estop" pkg="starling_mavros_extras" exec="estop" output="screen" respawn="true" namespace="$(var vehicle_namespace)"/>
 
+    <!-- Launch Ping Node -->
+    <node name="ping" pkg="starling_mavros_extras" exec="ping" output="screen" respawn="true" namespace="$(var vehicle_namespace)">
+        <param name="vehicle_id" value="$(var vehicle_namespace)"/>
+    </node>
+
 </launch>

--- a/system/mavros/starling_mavros_extras/CMakeLists.txt
+++ b/system/mavros/starling_mavros_extras/CMakeLists.txt
@@ -22,14 +22,19 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp  REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(mavros_msgs REQUIRED)
+find_package(diagnostic_msgs REQUIRED)
 
-set(HEADER_FILES include/estop.hpp)
-
-add_executable(estop src/estop.cpp ${HEADER_FILES})
+add_executable(estop src/estop.cpp include/estop.hpp)
 ament_target_dependencies(estop
   rclcpp std_msgs mavros_msgs
 )
 target_include_directories(estop PRIVATE include)
+
+add_executable(ping src/ping.cpp include/ping.hpp)
+ament_target_dependencies(ping
+  rclcpp std_msgs
+)
+target_include_directories(ping PRIVATE include)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -44,6 +49,7 @@ endif()
 
 install(TARGETS
   estop
+  ping
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/system/mavros/starling_mavros_extras/include/ping.hpp
+++ b/system/mavros/starling_mavros_extras/include/ping.hpp
@@ -1,0 +1,41 @@
+#ifndef PING_HPP
+#define PING_HPP
+
+/*
+ * Copyright (C) 2022 University of Bristol
+ *
+ * Author: Mickey Li <mickey.li@bristol.ac.uk> (University of Bristol)
+ *
+ * Distributed under MIT License (available at https://opensource.org/licenses/MIT).
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ */
+
+#include "rclcpp/rclcpp.hpp"
+
+#include <chrono>
+#include <memory>
+#include <algorithm>
+#include <stdexcept>
+#include <thread>
+#include <atomic>
+#include <cmath>
+
+#include <std_msgs/msg/header.hpp>
+
+class PingHandler : public rclcpp::Node
+{
+    public:
+        PingHandler();
+    
+    private:
+        void handle_ping(const std_msgs::msg::Header::SharedPtr s);
+
+        rclcpp::Subscription<std_msgs::msg::Header>::SharedPtr ping_sub;
+        rclcpp::Publisher<std_msgs::msg::Header>::SharedPtr ping_pub;
+
+        std::string vehicle_id;
+};
+
+
+#endif

--- a/system/mavros/starling_mavros_extras/src/ping.cpp
+++ b/system/mavros/starling_mavros_extras/src/ping.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2021 University of Bristol
+ *
+ * Author: Mickey Li <mickey.li@bristol.ac.uk> (University of Bristol)
+ *
+ * Distributed under MIT License (available at https://opensource.org/licenses/MIT).
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ */
+#include "ping.hpp"
+
+PingHandler::PingHandler() :
+	Node("ping_handler")
+{
+    this->declare_parameter("vehicle_id");
+    rclcpp::Parameter id_param = this->get_parameter("vehicle_id");
+    this->vehicle_id = id_param.as_string();
+
+    this->ping_sub = this->create_subscription<std_msgs::msg::Header>(
+        "/ping_source", 1, 
+        [this](const std_msgs::msg::Header::SharedPtr s){
+            this->handle_ping(s);
+        }
+    );
+
+    this->ping_pub = this->create_publisher<std_msgs::msg::Header>("/ping_sink", 10);
+
+    RCLCPP_INFO(this->get_logger(), "Ping Initialised");
+}
+
+void PingHandler::handle_ping(const std_msgs::msg::Header::SharedPtr s) {
+    std_msgs::msg::Header msg;
+    msg.frame_id = this->vehicle_id;
+    msg.stamp = s->stamp;
+    this->ping_pub->publish(msg);
+}
+
+int main(int argc, char **argv)
+{
+    rclcpp::init(argc, argv);
+    auto handler = std::make_shared<PingHandler>();
+    rclcpp::spin(handler);
+    rclcpp::shutdown();
+    return 0;
+}

--- a/system/ping_monitor/Dockerfile
+++ b/system/ping_monitor/Dockerfile
@@ -1,0 +1,38 @@
+ARG VERSION=latest
+ARG REGISTRY
+FROM ${REGISTRY}uobflightlabstarling/starling-controller-base:${VERSION}
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libboost-system-dev \
+        git \
+        wget \
+        python3-pip \
+        python3-scipy \
+        libgeographic-dev \
+        geographiclib-tools \
+        libeigen3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+## Ensure geographiclib is properly installed with FindGeographicLib available
+RUN wget https://raw.githubusercontent.com/mavlink/mavros/ros2/mavros/scripts/install_geographiclib_datasets.sh \
+    && bash install_geographiclib_datasets.sh \
+    && ln -s /usr/share/cmake/geographiclib/FindGeographicLib.cmake /usr/share/cmake-3.16/Modules/
+
+# Install Libinterpolate
+RUN git clone https://github.com/CD3/libInterpolate \
+    && cd libInterpolate && mkdir build && cd build \
+    && cmake .. \
+    && cmake --build . --target install \ 
+    && cd ../.. && rm -r libInterpolate
+
+# Copies all the nodes into the container
+COPY ping_monitor /ros_ws/src
+RUN . /opt/ros/${ROS_DISTRO}/setup.sh \
+    && export CMAKE_PREFIX_PATH=$AMENT_PREFIX_PATH:$CMAKE_PREFIX_PATH \
+    && cd /ros_ws \
+    && colcon build\
+    && rm -r build
+
+COPY ping_monitor/run.sh /ros_ws
+CMD ["./run.sh"]

--- a/system/ping_monitor/LICENSE
+++ b/system/ping_monitor/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 mickey li
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/system/ping_monitor/README.md
+++ b/system/ping_monitor/README.md
@@ -1,0 +1,4 @@
+# Ping Monitor
+
+A simple round trip ping monitor node
+

--- a/system/ping_monitor/deployment/docker-compose.yml
+++ b/system/ping_monitor/deployment/docker-compose.yml
@@ -1,0 +1,40 @@
+
+version: '3'
+
+services:
+  simhost: # Must be called simhost
+    image: uobflightlabstarling/starling-sim-iris-px4-flightarena:latest
+    ports:
+      - "8080:8080"
+
+  sitl:
+    image: uobflightlabstarling/starling-sim-px4-sitl:latest
+    environment:
+      - "PX4_SIM_HOST=simhost"
+      - "PX4_OFFBOARD_HOST=mavros"
+    depends_on:
+      - simhost
+    ports:
+      - "18570:18570/udp"
+
+  mavros:
+    image: uobflightlabstarling/starling-mavros:latest
+    command: ros2 launch launch/mavros_bridge.launch.xml
+    environment:
+      - "MAVROS_TGT_SYSTEM=1"
+      - "MAVROS_FCU_IP=0.0.0.0"
+      - "MAVROS_GCS_URL=tcp-l://0.0.0.0:5760"
+    depends_on:
+      - simhost
+    ports:
+      - "5760:5760"
+
+  rosbridge-suite:
+    image: uobflightlabstarling/rosbridge-suite:latest
+    ports:
+      - "9090:9090"
+
+  starling-ui-example:
+    image: uobflightlabstarling/starling-ui-example:latest
+    ports:
+      - "3000:3000"

--- a/system/ping_monitor/deployment/kubernetes.yaml
+++ b/system/ping_monitor/deployment/kubernetes.yaml
@@ -1,0 +1,34 @@
+# Central montior
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ping-monitor-offboard-controller
+  labels:
+    app: starling
+    project: ping-monitor
+spec:
+  selector:
+    matchLabels:
+      app:  ping-monitor-offboard-controller
+  template:
+    metadata:
+      labels:
+        app: ping-monitor-offboard-controller
+    spec:
+
+      hostNetwork: true
+      shareProcessNamespace: true
+
+      nodeSelector:
+        name: master
+
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+
+      containers:
+      - name: offboard-controller
+        image: uobflightlabstarling/ping-monitor
+        imagePullPolicy: Always
+

--- a/system/ping_monitor/ping_monitor/ping_monitor_server/package.xml
+++ b/system/ping_monitor/ping_monitor/ping_monitor_server/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ping_monitor_server</name>
+  <version>0.0.0</version>
+  <description>Ping Monitor Server</description>
+  <maintainer email="mickey.li@bristol.ac.uk">root</maintainer>
+  <license>MIT License @ mickey li 2022</license>
+
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>trajectory_msgs</exec_depend>
+
+  <!-- List custom message dependencies here -->
+  <!-- <exec_depend>ros2_msgs_template</exec_depend> -->
+  <exec_depend>template_msgs</exec_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/system/ping_monitor/ping_monitor/ping_monitor_server/ping_monitor_server/main.py
+++ b/system/ping_monitor/ping_monitor/ping_monitor_server/ping_monitor_server/main.py
@@ -1,0 +1,56 @@
+import random
+import time
+import numpy as np
+from functools import partial
+import itertools as it
+from scipy.stats import circmean
+
+import rclpy
+from rclpy.node import Node
+from rclpy.duration import Duration
+from rclpy.time import Time
+
+from std_msgs.msg import Header, Float32
+
+class Monitor(Node):
+
+    def __init__(self):
+        super().__init__('ping_monitor_server')
+
+        self.declare_parameter("frequency", 5)
+        self.declare_parameter("reporting_topic_name", "round_trip_time")
+
+        self.stream_topic_name = self.get_parameter("reporting_topic_name").value
+        self.ping_sink = self.create_subscription(Header, '/ping_sink', self.ping_sink_cb, 10)
+        self.ping_source = self.create_publisher(Header, "/ping_source", 10)
+        self.ping_vehicles_timer = self.create_timer(1.0 / self.get_parameter("frequency").value, self.ping_vehicles_timer_cb)
+        self.get_logger().info("Ping Monitor Initialised")
+
+    def ping_vehicles_timer_cb(self):
+        msg = Header()
+        msg.stamp = self.get_clock().now().to_msg()
+        self.ping_source.publish(msg)
+
+    def ping_sink_cb(self, msg):
+        now = self.get_clock().now()
+        time_elapsed = now - Time.from_msg(msg.stamp)
+
+        smsg = Float32()
+        smsg.data = time_elapsed.nanoseconds / 1e6
+        
+        if msg.frame_id != "":
+            pub = self.create_publisher(Float32, f"/{msg.frame_id}/{self.stream_topic_name}", 10)
+            pub.publish(smsg)
+
+            # self.get_logger().info(f"Received response from {msg.frame_id}, round_trip time of {smsg.data}ms")
+        else:
+            pass
+            # self.get_logger().info(f"Received response from unknown, frame_id not given")
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    mon = Monitor()
+    rclpy.spin(mon)
+    mon.destroy_node()
+    rclpy.shutdown()

--- a/system/ping_monitor/ping_monitor/ping_monitor_server/setup.cfg
+++ b/system/ping_monitor/ping_monitor/ping_monitor_server/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script-dir=$base/lib/ping_monitor_server
+[install]
+install-scripts=$base/lib/ping_monitor_server

--- a/system/ping_monitor/ping_monitor/ping_monitor_server/setup.py
+++ b/system/ping_monitor/ping_monitor/ping_monitor_server/setup.py
@@ -1,0 +1,26 @@
+from setuptools import setup
+
+package_name = 'ping_monitor_server'
+
+setup(
+    name=package_name,
+    version='0.0.0',
+    packages=[package_name],
+    data_files=[
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+    ],
+    install_requires=['setuptools'],
+    zip_safe=True,
+    maintainer='mickey li',
+    maintainer_email='mickey.li@bristol.ac.uk',
+    description='Ping Monitor Server',
+    license='MIT License @ mickey li 2022',
+    tests_require=['pytest'],
+    entry_points={
+        'console_scripts': [
+            'controller = ping_monitor_server.main:main'
+        ],
+    },
+)

--- a/system/ping_monitor/ping_monitor/ping_monitor_server/test/test_copyright.py
+++ b/system/ping_monitor/ping_monitor/ping_monitor_server/test/test_copyright.py
@@ -1,0 +1,23 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_copyright.main import main
+import pytest
+
+
+@pytest.mark.copyright
+@pytest.mark.linter
+def test_copyright():
+    rc = main(argv=['.', 'test'])
+    assert rc == 0, 'Found errors'

--- a/system/ping_monitor/ping_monitor/ping_monitor_server/test/test_flake8.py
+++ b/system/ping_monitor/ping_monitor/ping_monitor_server/test/test_flake8.py
@@ -1,0 +1,25 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_flake8.main import main_with_errors
+import pytest
+
+
+@pytest.mark.flake8
+@pytest.mark.linter
+def test_flake8():
+    rc, errors = main_with_errors(argv=[])
+    assert rc == 0, \
+        'Found %d code style errors / warnings:\n' % len(errors) + \
+        '\n'.join(errors)

--- a/system/ping_monitor/ping_monitor/ping_monitor_server/test/test_pep257.py
+++ b/system/ping_monitor/ping_monitor/ping_monitor_server/test/test_pep257.py
@@ -1,0 +1,23 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_pep257.main import main
+import pytest
+
+
+@pytest.mark.linter
+@pytest.mark.pep257
+def test_pep257():
+    rc = main(argv=['.', 'test'])
+    assert rc == 0, 'Found code style errors / warnings'

--- a/system/ping_monitor/ping_monitor/run.sh
+++ b/system/ping_monitor/ping_monitor/run.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+if [[ -f "/etc/starling/vehicle.config" ]]; then
+    echo "Sourcing local vehicle configuration"
+    source "/etc/starling/vehicle.config"
+fi
+
+if [[ -f "/ros_ws/install/setup.bash" ]]; then
+    echo "Sourcing local install setup.bash"
+    source "/ros_ws/install/setup.bash"
+fi
+
+if [ ! -v $VEHICLE_MAVLINK_SYSID ]; then
+    export VEHICLE_MAVLINK_SYSID=$VEHICLE_MAVLINK_SYSID
+    echo "VEHICLE_MAVLINK_SYSID setting to $VEHICLE_MAVLINK_SYSID"
+else
+    export VEHICLE_MAVLINK_SYSID=1
+    echo "VEHICLE_MAVLINK_SYSID not set, default to 1"
+fi
+
+ros2 run ping_monitor_server controller


### PR DESCRIPTION
Implemented a simple round trip time calculator using a centralised pinging mechanism. 
Central server detects time difference and broadcasts the floating point time difference in milliseconds over `/<vehicle_id>/round_trip_time` for a program like foxglove to monitor. 

Onboard ping node is built into mavros, 
Offboard ping node is its own contianer